### PR TITLE
update build images to the newly created buster build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: clang-format -i -style=file src/*.{c,h} misc/*.{c,h} nasl/*.{c,h} && git diff --exit-code
   test_units:
     docker:
-      - image: greenbone/build-env-openvas-scanner-master-debian-stretch-gcc-core
+      - image: greenbone/build-env-openvas-scanner-master-debian-buster-gcc-core
     steps:
       - run:
           working_directory: ~/gvm-libs
@@ -26,7 +26,7 @@ jobs:
           command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make tests && CTEST_OUTPUT_ON_FAILURE=1 make test
   build_gcc_core:
     docker:
-      - image: greenbone/build-env-openvas-scanner-master-debian-stretch-gcc-core
+      - image: greenbone/build-env-openvas-scanner-master-debian-buster-gcc-core
     steps:
       - run:
           working_directory: ~/gvm-libs
@@ -42,7 +42,7 @@ jobs:
           command: mkdir build && cd build/ && cmake -DCMAKE_BUILD_TYPE=Release .. && make install
   scan_build:
     docker:
-      - image: greenbone/build-env-openvas-scanner-master-debian-stretch-clang-core
+      - image: greenbone/build-env-openvas-scanner-master-debian-buster-clang-core
     steps:
       - run:
           working_directory: ~/gvm-libs


### PR DESCRIPTION
# Verification

## failing run
```
docker run -it -v (pwd):/mnt greenbone/build-env-openvas-scanner-master-debian-stretch-clang-core bash
```
then inside the container
```
cd ~/ && git clone --depth 1 https://github.com/greenbone/gvm-libs.git && cd gvm-libs &&\
	mkdir build && cd build/ &&\
	cmake -DCMAKE_BUILD_TYPE=Debug .. && make install
cd /mnt && mkdir build && cd build &&\
	cmake -DCMAKE_BUILD_TYPE=Release .. && make install
```

## successful run
```
docker run -it -v (pwd):/mnt greenbone/build-env-openvas-scanner-master-debian-buster-clang-core bash
```
then inside the container
```
cd ~/ && git clone --depth 1 https://github.com/greenbone/gvm-libs.git && cd gvm-libs &&\
	mkdir build && cd build/ &&\
	cmake -DCMAKE_BUILD_TYPE=Debug .. && make install
cd /mnt && mkdir build && cd build &&\
	cmake -DCMAKE_BUILD_TYPE=Release .. && make install
```